### PR TITLE
Fix incorrectly named arg bug

### DIFF
--- a/granule_ingester/granule_ingester/main.py
+++ b/granule_ingester/granule_ingester/main.py
@@ -107,7 +107,7 @@ async def main(loop):
                         default='http://localhost:8983',
                         metavar='HOST:PORT',
                         help='Solr host and port. (Default: http://localhost:8983)')
-    parser.add_argument('--zk_host_and_port',
+    parser.add_argument('--zk-host-and-port',
                         metavar="HOST:PORT")
     
     # ELASTIC


### PR DESCRIPTION
Fixed bug where arg `--zk-host-and-port` was incorrectly named `--zk_host_and_port`