### PR TITLE
SDAP-534 - Better handling of data vars in NetCDF groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - Unreleased
 ### Added
+- SDAP-534: Added proper support for data variables in NetCDF groups. Can handle multiple data variables across different groups. Coordinates are still required to be in root.
 ### Changed
 ### Deprecated
 ### Removed

--- a/collection_manager/collection_manager/services/CollectionProcessor.py
+++ b/collection_manager/collection_manager/services/CollectionProcessor.py
@@ -151,6 +151,23 @@ class CollectionProcessor:
             'processors': CollectionProcessor._get_default_processors(collection)
         }
 
+        group_vars = []
+
+        for name, value in collection.dimension_names:
+            if name != 'variable':
+                continue
+            else:
+                value = json.loads(value)
+
+                if isinstance(value, str):
+                    value = [value]
+
+                for v in value:
+                    parts = v.split('/')
+
+                    if len(parts) > 1:
+                        group_vars.append(v)
+
         if collection.preprocess is not None:
             config_dict['preprocess'] = json.loads(collection.preprocess)
 
@@ -159,6 +176,9 @@ class CollectionProcessor:
 
         if collection.group is not None:
             config_dict['granule']['group'] = collection.group
+
+        if len(group_vars) > 0:
+            config_dict['granule']['grouped_vars'] = group_vars
 
         config_str = yaml.dump(config_dict)
         logger.debug(f"Templated dataset config:\n{config_str}")

--- a/granule_ingester/granule_ingester/granule_loaders/GranuleLoader.py
+++ b/granule_ingester/granule_ingester/granule_loaders/GranuleLoader.py
@@ -42,6 +42,8 @@ class GranuleLoader:
         if 'preprocess' in kwargs:
             self._preprocess = [GranuleLoader._parse_module(module) for module in kwargs['preprocess']]
 
+        self._group_vars = kwargs.get('grouped_vars', {})
+
     async def __aenter__(self):
         return await self.open()
 
@@ -69,6 +71,15 @@ class GranuleLoader:
                 additional_params['group'] = self._group
 
             ds = xr.open_dataset(file_path, lock=False, **additional_params)
+
+            for group_var in self._group_vars:
+                parts = group_var.split('/')
+
+                group = '/'.join(parts[:-1])
+                var_name = parts[-1]
+
+                ds_grp = xr.open_dataset(file_path, lock=False, group=group)
+                ds[group_var] = ds_grp[var_name]
 
             if self._preprocess is not None:
                 logger.info(f'There are {len(self._preprocess)} preprocessors to apply for granule {self._resource}')

--- a/granule_ingester/granule_ingester/granule_loaders/GranuleLoader.py
+++ b/granule_ingester/granule_ingester/granule_loaders/GranuleLoader.py
@@ -42,7 +42,7 @@ class GranuleLoader:
         if 'preprocess' in kwargs:
             self._preprocess = [GranuleLoader._parse_module(module) for module in kwargs['preprocess']]
 
-        self._group_vars = kwargs.get('grouped_vars', {})
+        self._group_vars = kwargs.get('grouped_vars', [])
 
     async def __aenter__(self):
         return await self.open()


### PR DESCRIPTION
Previous approach required either all data variables and coordinate arrays to be in the opened group (root by default)

Now data variables can be defined with paths with groups separated by `/` (ie, `group/var` for the variable `var` in root-level group `group`)

Coordinate variables are still required to be colocated in the same group as the `group` field (optional; root by default). We should eventually deprecate and remove this entirely in favor of this pathed approach