### PR TITLE
[SDAP-539] Fix quiet dropping of S3 granules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 ### Removed
 ### Fixed
+- SDAP-539: Fixed issue where similar S3 paths could lead to granules being incorrectly and quietly ignored in very specific scenarios
 - Fixed issue with Collection Manager Docker build failing due to setuptools issue
 ### Security
 

--- a/collection_manager/collection_manager/services/CollectionWatcher.py
+++ b/collection_manager/collection_manager/services/CollectionWatcher.py
@@ -243,8 +243,8 @@ class _GranuleEventHandler(FileSystemEventHandler):
                     self._loop.create_task(self._callback(path, modified_time, collection))
                 else:
                     logger.error(f'Event for file {path} will be discarded as it is not owned by the collection it '
-                                 f'matched to: {collection.dataset_id}. This should not happen. Please report this '
-                                 f'with the relevant logs and collection configuration to dev@sdap.apache.org or '
-                                 f'https://issues.apache.org/jira/projects/SDAP/issues/')
+                                 f'matched to: {collection.dataset_id} ({collection.path}). This should not happen. '
+                                 f'Please report this with the relevant logs and collection configuration to '
+                                 f'dev@sdap.apache.org or https://issues.apache.org/jira/projects/SDAP/issues/')
             except IsADirectoryError:
                 return

--- a/collection_manager/collection_manager/services/CollectionWatcher.py
+++ b/collection_manager/collection_manager/services/CollectionWatcher.py
@@ -241,5 +241,10 @@ class _GranuleEventHandler(FileSystemEventHandler):
                     else:
                         modified_time = int(os.path.getmtime(path))
                     self._loop.create_task(self._callback(path, modified_time, collection))
+                else:
+                    logger.error(f'Event for file {path} will be discarded as it is not owned by the collection it '
+                                 f'matched to: {collection.dataset_id}. This should not happen. Please report this '
+                                 f'with the relevant logs and collection configuration to dev@sdap.apache.org or '
+                                 f'https://issues.apache.org/jira/projects/SDAP/issues/')
             except IsADirectoryError:
                 return

--- a/collection_manager/collection_manager/services/S3Observer.py
+++ b/collection_manager/collection_manager/services/S3Observer.py
@@ -152,7 +152,7 @@ class S3Observer:
         return new_cache
 
     def _get_object_key(full_path: str):
-        key = urlparse(full_path).path.strip("/")
+        key = urlparse(full_path).path.lstrip("/")
         return key
 
 


### PR DESCRIPTION
Quick fix of an issue where similar S3 paths could cause granules to be incorrectly dropped.

This fix could be a bit more robust, as it does depend on S3 paths being defined with trailing `/`s, but this is a rare enough issue that this should be sufficient for now. In the even this issue does reoccur, I have added a specific log statement so that it will be easier to capture when it happens.