### PR TITLE
Collection Manager: Skip remote collections when reloading config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - SDAP-534: Added proper support for data variables in NetCDF groups. Can handle multiple data variables across different groups. Coordinates are still required to be in root.
 ### Changed
+- Properly handle skipping of remote collections when reloading the collections conig in the CM.
 ### Deprecated
 ### Removed
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - SDAP-534: Added proper support for data variables in NetCDF groups. Can handle multiple data variables across different groups. Coordinates are still required to be in root.
 ### Changed
-- Properly handle skipping of remote collections when reloading the collections conig in the CM.
+- Properly handle skipping of remote collections when reloading the collections config in the CM.
 ### Deprecated
 ### Removed
 ### Fixed

--- a/collection_manager/collection_manager/services/CollectionWatcher.py
+++ b/collection_manager/collection_manager/services/CollectionWatcher.py
@@ -101,6 +101,10 @@ class CollectionWatcher:
             logger.info('Refreshing collection config')
 
             for collection_dict in collections_yaml['collections']:
+                if 'remote-id' in collection_dict:
+                    logger.info(f'Collection "{collection_dict.get("id", "NO ID")}" is remotely configured. Skipping.')
+                    continue
+
                 try:
                     collection = Collection.from_dict(collection_dict)
                     if collection.storage_type() == CollectionStorageType.ZARR:


### PR DESCRIPTION
Currently, remote collections in the collection config raise a KeyError, which leads to the logs being cluttered with incorrect ERROR messages and tracebacks. In this PR, we check for these collections and skip handling them with a simple INFO statement.